### PR TITLE
Fix TypeScript types for `set` method

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
     "eslint-config-xo-typescript": "^0.14.0",
     "npm-run-all": "^4.1.5",
     "tsify": "^4.0.1",
-    "type-fest": "^0.5.2",
     "typescript": "^3.5.2",
     "xo": "*"
   },
   "dependencies": {
+    "type-fest": "^0.5.2",
     "webext-detect-page": "^0.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-config-xo-typescript": "^0.14.0",
     "npm-run-all": "^4.1.5",
     "tsify": "^4.0.1",
+    "type-fest": "^0.5.2",
     "typescript": "^3.5.2",
     "xo": "*"
   },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
       "browser",
       "webextensions"
     ],
+    "rules": {
+      "import/no-unresolved": "warn"
+    },
     "overrides": [
       {
         "files": "**/*.ts",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "eslint-config-xo-typescript": "^0.14.0",
     "npm-run-all": "^4.1.5",
     "tsify": "^4.0.1",
-    "type-fest": "^0.5.2",
     "typescript": "^3.5.2",
     "xo": "*"
   },

--- a/source/index.ts
+++ b/source/index.ts
@@ -165,7 +165,7 @@ class OptionsSync<TOptions extends OptionsSync.Options> {
 
 	@param newOptions - A map of default options as strings or booleans. The keys will have to match the form fields' `name` attributes.
 	*/
-	async setAll(newOptions: TOptions): Promise<void> {
+	async setAll(newOptions: Partial<TOptions>): Promise<void> {
 		return new Promise((resolve, reject) => {
 			chrome.storage.sync.set({
 				[this.storageName]: newOptions

--- a/source/index.ts
+++ b/source/index.ts
@@ -165,7 +165,7 @@ class OptionsSync<TOptions extends OptionsSync.Options> {
 
 	@param newOptions - A map of default options as strings or booleans. The keys will have to match the form fields' `name` attributes.
 	*/
-	async setAll(newOptions: TOptions): Promise<void> {
+	async setAll(newOptions: Partial<TOptions>): Promise<void> {
 		return new Promise((resolve, reject) => {
 			chrome.storage.sync.set({
 				[this.storageName]: newOptions
@@ -184,7 +184,7 @@ class OptionsSync<TOptions extends OptionsSync.Options> {
 
 	@param newOptions - A map of default options as strings or booleans. The keys will have to match the form fields' `name` attributes.
 	*/
-	async set(newOptions: Partial<TOptions>): Promise<void> {
+	async set(newOptions: TOptions): Promise<void> {
 		return this.setAll({...await this.getAll(), ...newOptions});
 	}
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -261,7 +261,7 @@ class OptionsSync<TOptions extends OptionsSync.Options> {
 	}
 
 	_handleFormUpdates(el: HTMLFormElement): void {
-		const {name} = el;
+		const {name}: {name: keyof TOptions} = el;
 		let {value} = el;
 		if (!name || !el.validity.valid) {
 			return;
@@ -278,9 +278,10 @@ class OptionsSync<TOptions extends OptionsSync.Options> {
 		}
 
 		this._log('info', 'Saving option', el.name, 'to', value);
+		// @ts-ignore `name` should be a keyof TOptions but it's a plain string, so it fails
 		this.set({
 			[name]: value
-		} as TOptions);
+		});
 	}
 }
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -165,7 +165,7 @@ class OptionsSync<TOptions extends OptionsSync.Options> {
 
 	@param newOptions - A map of default options as strings or booleans. The keys will have to match the form fields' `name` attributes.
 	*/
-	async setAll(newOptions: Partial<TOptions>): Promise<void> {
+	async setAll(newOptions: TOptions): Promise<void> {
 		return new Promise((resolve, reject) => {
 			chrome.storage.sync.set({
 				[this.storageName]: newOptions
@@ -184,7 +184,7 @@ class OptionsSync<TOptions extends OptionsSync.Options> {
 
 	@param newOptions - A map of default options as strings or booleans. The keys will have to match the form fields' `name` attributes.
 	*/
-	async set(newOptions: TOptions): Promise<void> {
+	async set(newOptions: Partial<TOptions>): Promise<void> {
 		return this.setAll({...await this.getAll(), ...newOptions});
 	}
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,3 +1,4 @@
+import {RequireAtLeastOne} from 'type-fest';
 import {isBackgroundPage} from 'webext-detect-page';
 
 declare namespace OptionsSync {
@@ -165,7 +166,7 @@ class OptionsSync<TOptions extends OptionsSync.Options> {
 
 	@param newOptions - A map of default options as strings or booleans. The keys will have to match the form fields' `name` attributes.
 	*/
-	async setAll(newOptions: Partial<TOptions>): Promise<void> {
+	async setAll(newOptions: TOptions): Promise<void> {
 		return new Promise((resolve, reject) => {
 			chrome.storage.sync.set({
 				[this.storageName]: newOptions
@@ -184,7 +185,7 @@ class OptionsSync<TOptions extends OptionsSync.Options> {
 
 	@param newOptions - A map of default options as strings or booleans. The keys will have to match the form fields' `name` attributes.
 	*/
-	async set(newOptions: TOptions): Promise<void> {
+	async set(newOptions: RequireAtLeastOne<TOptions>): Promise<void> {
 		return this.setAll({...await this.getAll(), ...newOptions});
 	}
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,4 +1,3 @@
-import {RequireAtLeastOne} from 'type-fest';
 import {isBackgroundPage} from 'webext-detect-page';
 
 declare namespace OptionsSync {
@@ -166,7 +165,7 @@ class OptionsSync<TOptions extends OptionsSync.Options> {
 
 	@param newOptions - A map of default options as strings or booleans. The keys will have to match the form fields' `name` attributes.
 	*/
-	async setAll(newOptions: TOptions): Promise<void> {
+	async setAll(newOptions: Partial<TOptions>): Promise<void> {
 		return new Promise((resolve, reject) => {
 			chrome.storage.sync.set({
 				[this.storageName]: newOptions
@@ -185,7 +184,7 @@ class OptionsSync<TOptions extends OptionsSync.Options> {
 
 	@param newOptions - A map of default options as strings or booleans. The keys will have to match the form fields' `name` attributes.
 	*/
-	async set(newOptions: RequireAtLeastOne<TOptions>): Promise<void> {
+	async set(newOptions: TOptions): Promise<void> {
 		return this.setAll({...await this.getAll(), ...newOptions});
 	}
 


### PR DESCRIPTION
From https://github.com/bfred-it/webext-options-sync/commit/fc77d661742e95ecefce66d0b738c1e3a7d7aae3#r34067329.

Fixes [Travis build](https://travis-ci.org/sindresorhus/refined-github/jobs/550317445#L319) over at https://github.com/sindresorhus/refined-github/pull/2146.